### PR TITLE
Update fzf-select-option for multi-selection

### DIFF
--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -20,7 +20,7 @@ _get_command() {
 }
 
 _remove_line_number() {
-    sed "s/^.*://g"
+    sed "s/^.*:/ /g"
 }
 
 options=$(getopt -o h --long help -- "$@")
@@ -63,4 +63,5 @@ opts="$($this_dir/cli-options $cmd)"
 echo "$opts" | _remove_line_number |
 fzf --prompt="$buffer" \
     --preview "echo \"$opts\" | $this_dir/bat-cli-option \"$cmd\" {}; [ {q} ];" \
-    $FZF_HELP_OPTS
+    $FZF_HELP_OPTS |
+    tr -d '\n'


### PR DESCRIPTION
Minor changes to allow multi-selection

Added a space where line numbers are being removed and removed trailing new lines before returning value.

This allows '-m' to be passed in 'FZF-HELP-OPTS' for selecting multiple options to insert to stdin. I have not found any bugs in the case there are two spaces after command before first option when running.