### PR TITLE
Added -p flag to mkdir in install script

### DIFF
--- a/install
+++ b/install
@@ -46,6 +46,6 @@ if [[ -d $plugin_dir ]]; then
 fi
 
 echo "Copying fzf-help to $plugin_dir"
-sudo mkdir $plugin_dir || abort
+sudo mkdir -p $plugin_dir || abort
 sudo cp $this_dir/src/* $plugin_dir || abort
 echo 'Installation complete.'


### PR DESCRIPTION
I was installing on Debian Bookworm and did not have the folder `/usr/share/zsh/plugins` so trying to create `/usr/share/zsh/plugins/fzf-help` failed. It seems creating parent directories should be pretty harmless for the install process.