### PR TITLE
Reversed the way options are browsed inside fzf.

### DIFF
--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -52,7 +52,7 @@ get_command() {
 
 get_fzf_help_opts() {
     if [[ -z $FZF_HELP_OPTS ]]; then
-        FZF_HELP_OPTS="--multi --preview-window=right,75%,wrap --height 80% "
+        FZF_HELP_OPTS="--multi --layout=reverse --preview-window=right,75%,wrap --height 80% "
         FZF_HELP_OPTS+="--bind ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)"
     fi
 }


### PR DESCRIPTION
Currently, cursor movement in the left pane is bottom-to-top, while movement in the right pane is top-to-bottom. It seemed a bit odd hence introduced this change.

Current: https://asciinema.org/a/Q1t5M5BhMo6n83vTps65lYkhx

After layout reversal: https://asciinema.org/a/AELf8GNNg9v4dJBl5lfzzJt8F

Perhaps, we can introduce an env var to control this.
