### PR TITLE
fix: mktemp and grep do not work on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Ensure that you have the following tools installed:
 - [fzf](https://github.com/junegunn/fzf)
 - [bat](https://www.github.com/sharkdp/bat) (optional, but recommended)
 
+### MacOS
+
+Ensure that [GNU grep](https://www.gnu.org/software/grep/) is installed and
+available either as `ggrep` or `grep`:
+
+```zsh
+brew install grep # Installs GNU grep as ggrep
+```
+
 On Arch, for example, you can install these tools with:
 
 ```zsh

--- a/src/cli-options
+++ b/src/cli-options
@@ -40,6 +40,11 @@ SHORT="($PREFIX)($TAIL)"
 
 RE="$LONG|$SHORT"
 
+# If on macOS check if GNU grep is installed as ggrep
+if [[ "$(uname)" == "Darwin" ]] && [[ "$(command -v ggrep 2>/dev/null)" ]]; then
+    GREP_CMD="ggrep"
+fi
+
 parse_args "$@"
-cli_options_cmd="${CLI_OPTIONS_CMD:-"grep -o --line-number -P -- \"$RE\""}"
+cli_options_cmd="${CLI_OPTIONS_CMD:-"${GREP_CMD:-grep} -o --line-number -P -- \"$RE\""}"
 eval "$cli_options_cmd"

--- a/src/help-message
+++ b/src/help-message
@@ -44,7 +44,7 @@ parse_args() {
 
 get_temp() {
     local tmpdir file
-    tmpdir=$(dirname "$(mktemp tmp.XXXXXXXXXX -ut)")
+    tmpdir=$(dirname "$(mktemp -u)")
     file="$tmpdir/fzf-help-message"
     touch "$file"
     echo "$file"


### PR DESCRIPTION
Fixes #24