### PR TITLE
Handle empty selector results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bat zsh
+          sudo apt-get install --yes bat fish zsh
           git submodule update --init --recursive
 
       - name: Run Bats Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ If a change is breaking, this is mentioned and a major version is released.
 - The selector accepts one-character long options and rejects extra commands.
 - The shell integrations work when their path contains spaces.
 - `FZF_HELP_OPTS` preserves spaces in each fzf argument.
+- The selector displays its empty preview if it finds no options.
+- The shell widgets preserve the command buffer when selection fails.
 
 ## Task
 

--- a/src/fzf-help.bash
+++ b/src/fzf-help.bash
@@ -10,10 +10,17 @@ _fzf_help_directory=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 fzf-help-widget() {
     [[ -z $READLINE_LINE ]] && { return; }
 
-    local opts=$(echo $READLINE_LINE | $_fzf_help_directory/fzf-select-option | tr "\n" " ")
+    local opts ret
+    if opts=$(printf '%s\n' "$READLINE_LINE" | "$_fzf_help_directory/fzf-select-option"); then
+        :
+    else
+        ret=$?
+        return "$ret"
+    fi
+
+    opts=$(tr '\n' ' ' <<<"$opts")
     READLINE_LINE="$READLINE_LINE$opts"
     READLINE_POINT=${#READLINE_LINE}
 
-    local ret=$?
-    return $ret
+    return 0
 }

--- a/src/fzf-help.fish
+++ b/src/fzf-help.fish
@@ -11,9 +11,15 @@ function fzf-help-widget
   if test -z (commandline)
     return
   end
-  set -l cmd (echo -n (commandline|string collect))
-  set -l opts (echo -n (commandline|string collect)| $_fzf_help_directory/fzf-select-option | tr "\n" " "|string collect)
+  set -l cmd (commandline|string collect)
+  set -l opts (printf '%s\n' "$cmd" | $_fzf_help_directory/fzf-select-option)
+  set -l selector_status $status
+  if test "$selector_status" -ne 0
+    commandline -f repaint
+    return $selector_status
+  end
+  set opts (string join ' ' -- $opts)
   commandline -r -- $cmd$opts
   commandline -f repaint
-  return $status
+  return 0
 end

--- a/src/fzf-help.zsh
+++ b/src/fzf-help.zsh
@@ -10,11 +10,20 @@ _fzf_help_directory=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 fzf-help-widget() {
     [[ -z $BUFFER ]] && { zle reset-prompt; return }
 
-    local opts=$(echo $BUFFER | $_fzf_help_directory/fzf-select-option | tr "\n" " ")
+    local opts ret
+    if opts=$(printf '%s\n' "$BUFFER" | "$_fzf_help_directory/fzf-select-option"); then
+        :
+    else
+        ret=$?
+        zle reset-prompt
+        zle end-of-line
+        return "$ret"
+    fi
+
+    opts=$(tr '\n' ' ' <<<"$opts")
     BUFFER="$BUFFER$opts"
 
-    local ret=$?
     zle reset-prompt
     zle end-of-line
-    return $ret
+    return 0
 }

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -53,50 +53,105 @@ parse_args() {
     done
 
     if [[ -z $cmd ]]; then
-        cmd="$(cat -)"
+        cmd=$(read_command_from_stdin)
     fi
 
-    cmd=$(get_command <<<"$cmd")
+    cmd=$(remove_command_options "$cmd")
 }
 
-get_command() {
-    sed "s/\( -\).*$//"
+read_command_from_stdin() {
+    cat -
 }
 
-get_fzf_help_opts() {
+remove_command_options() {
+    sed "s/\( -\).*$//" <<<"$1"
+}
+
+set_default_fzf_help_opts() {
+    fzf_help_opts=(
+        --multi
+        --layout=reverse
+        --preview-window=right,75%,wrap
+        --height
+        80%
+        --bind
+        'ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)'
+    )
+}
+
+set_configured_fzf_help_opts() {
+    local fzf_help_opt
+
+    if [[ $FZF_HELP_OPTS == *$'\n'* ]]; then
+        while IFS= read -r fzf_help_opt; do
+            [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")
+        done <<<"$FZF_HELP_OPTS"
+    else
+        read -r -a fzf_help_opts <<<"$FZF_HELP_OPTS"
+    fi
+}
+
+set_fzf_help_opts() {
     # Bash 3.2, which macOS provides, does not support [[ -v variable ]].
     if [[ -n ${FZF_HELP_OPTS+x} ]]; then
-        if [[ $FZF_HELP_OPTS == *$'\n'* ]]; then
-            while IFS= read -r fzf_help_opt; do
-                [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")
-            done <<<"$FZF_HELP_OPTS"
-        else
-            read -r -a fzf_help_opts <<<"$FZF_HELP_OPTS"
-        fi
+        set_configured_fzf_help_opts
     else
-        fzf_help_opts=(
-            --multi
-            --layout=reverse
-            --preview-window=right,75%,wrap
-            --height
-            80%
-            --bind
-            'ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)'
-        )
+        set_default_fzf_help_opts
+    fi
+}
+
+get_options() {
+    local options status
+
+    if options=$("$dir/help-message" "$cmd" | "$dir/cli-options"); then
+        printf '%s\n' "$options"
+    else
+        status=$?
+        [[ $status -eq 1 ]] && return 0
+        return "$status"
     fi
 }
 
 get_preview_cmd() {
-    if [[ -z $opts ]]; then
-        echo "echo \"No help page or options found for $cmd\""
+    local options=$1
+
+    if [[ -z $options ]]; then
+        printf 'echo "No help page or options found for %s"\n' "$cmd"
     else
         # Uses the cached help message, see help-message.
-        echo "$dir/help-message | $dir/fzf-select-option-preview \"$opts\" {n}"
+        printf '%s\n' "$dir/help-message | $dir/fzf-select-option-preview \"$options\" {n}"
     fi
 }
 
-remove_line_number() {
+remove_line_numbers() {
     sed "s/^.*://g"
+}
+
+select_options() {
+    local options=$1
+    local preview_cmd=$2
+
+    remove_line_numbers <<<"$options" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}"
+}
+
+show_options() {
+    local options=$1
+    local preview_cmd=$2
+    local selection
+
+    if [[ -z $options ]]; then
+        if select_options "No options available." "$preview_cmd" >/dev/null; then
+            return 1
+        else
+            return $?
+        fi
+    fi
+
+    if selection=$(select_options "$options" "$preview_cmd"); then
+        printf '%s\n' "$selection"
+    else
+        return $?
+    fi
 }
 
 fzf_debug() {
@@ -119,28 +174,9 @@ fzf_help_opts=()
 parse_args "$@"
 [[ -z $cmd ]] && echo "$usage" && exit 1
 
-get_fzf_help_opts
+set_fzf_help_opts
 
 dir=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
-if opts="$("$dir/help-message" "$cmd" | "$dir/cli-options")"; then
-    :
-else
-    opts_status=$?
-    [[ $opts_status -ne 1 ]] && exit "$opts_status"
-    opts=""
-fi
-preview_cmd=$(get_preview_cmd)
-
-no_options=false
-if [[ -z $opts ]]; then
-    opts="No options available."
-    no_options=true
-fi
-
-selection=$(remove_line_number <<<"$opts" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}")
-
-if $no_options; then
-    exit 1
-fi
-
-printf '%s\n' "$selection"
+options=$(get_options)
+preview_cmd=$(get_preview_cmd "$options")
+show_options "$options" "$preview_cmd"

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -122,7 +122,13 @@ parse_args "$@"
 get_fzf_help_opts
 
 dir=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
-opts="$("$dir/help-message" "$cmd" | "$dir/cli-options")"
+if opts="$("$dir/help-message" "$cmd" | "$dir/cli-options")"; then
+    :
+else
+    opts_status=$?
+    [[ $opts_status -ne 1 ]] && exit "$opts_status"
+    opts=""
+fi
 preview_cmd=$(get_preview_cmd)
 
 remove_line_number <<<"$opts" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}"

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -57,6 +57,7 @@ parse_args() {
     fi
 
     cmd=$(remove_command_options "$cmd")
+    cmd=$(trim_command_whitespace "$cmd")
 }
 
 read_command_from_stdin() {
@@ -65,6 +66,10 @@ read_command_from_stdin() {
 
 remove_command_options() {
     sed "s/\( -\).*$//" <<<"$1"
+}
+
+trim_command_whitespace() {
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<<"$1"
 }
 
 set_default_fzf_help_opts() {

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -130,8 +130,10 @@ remove_line_numbers() {
 select_options() {
     local options=$1
     local preview_cmd=$2
+    local selectable_options
 
-    remove_line_numbers <<<"$options" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}"
+    selectable_options=$(remove_line_numbers <<<"$options")
+    "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}" <<<"$selectable_options"
 }
 
 show_options() {

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -131,4 +131,16 @@ else
 fi
 preview_cmd=$(get_preview_cmd)
 
-remove_line_number <<<"$opts" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}"
+no_options=false
+if [[ -z $opts ]]; then
+    opts="No options available."
+    no_options=true
+fi
+
+selection=$(remove_line_number <<<"$opts" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}")
+
+if $no_options; then
+    exit 1
+fi
+
+printf '%s\n' "$selection"

--- a/test/fzf-help-widget.bats
+++ b/test/fzf-help-widget.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# vim: ft=bash
+load test_helper/bats-assert/load
+load test_helper/bats-support/load
+
+setup() {
+    selector_dir="$BATS_TEST_TMPDIR/selector"
+    mkdir "$selector_dir"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit "$FZF_HELP_TEST_STATUS"' > "$selector_dir/fzf-select-option"
+    chmod +x "$selector_dir/fzf-select-option"
+}
+
+@test "The Bash widget keeps its buffer after a failed or cancelled selection" {
+    local expected
+
+    for expected in 1 130; do
+        run env FZF_HELP_TEST_STATUS="$expected" bash -c '
+            source "$1"
+            _fzf_help_directory="$2"
+            READLINE_LINE="git status"
+            READLINE_POINT=${#READLINE_LINE}
+            fzf-help-widget
+            selector_status=$?
+            printf "status=%s\nline=%s\npoint=%s\n" "$selector_status" "$READLINE_LINE" "$READLINE_POINT"
+            exit "$selector_status"
+        ' bash "$BATS_TEST_DIRNAME/../src/fzf-help.bash" "$selector_dir"
+
+        [ "$status" -eq "$expected" ]
+        assert_output $'status='"$expected"$'\nline=git status\npoint=10'
+    done
+}
+
+@test "The Zsh widget keeps its buffer after a failed or cancelled selection" {
+    local expected
+
+    for expected in 1 130; do
+        run env FZF_HELP_TEST_STATUS="$expected" zsh -fc '
+            zle() { return 0; }
+            source "$1"
+            _fzf_help_directory="$2"
+            BUFFER="git status"
+            fzf-help-widget
+            selector_status=$?
+            print -r -- "status=$selector_status"
+            print -r -- "buffer=$BUFFER"
+            exit "$selector_status"
+        ' zsh "$BATS_TEST_DIRNAME/../src/fzf-help.zsh" "$selector_dir"
+
+        [ "$status" -eq "$expected" ]
+        assert_output $'status='"$expected"$'\nbuffer=git status'
+    done
+}
+
+@test "The Fish widget keeps its buffer after a failed or cancelled selection" {
+    local expected fish_code
+    fish_code='
+        function commandline
+            if test (count $argv) -eq 0
+                printf "%s" "$FZF_HELP_TEST_BUFFER"
+                return 0
+            end
+
+            if test "$argv[1]" = "-r"
+                set -g FZF_HELP_TEST_BUFFER "$argv[3]"
+            end
+
+            return 0
+        end
+
+        source $argv[1]
+        set _fzf_help_directory $argv[2]
+        fzf-help-widget
+        set selector_status $status
+        printf "status=%s\nbuffer=%s\n" $selector_status "$FZF_HELP_TEST_BUFFER"
+        exit $selector_status
+    '
+
+    for expected in 1 130; do
+        run env FZF_HELP_TEST_STATUS="$expected" FZF_HELP_TEST_BUFFER="git status" fish -c "$fish_code" "$BATS_TEST_DIRNAME/../src/fzf-help.fish" "$selector_dir"
+
+        [ "$status" -eq "$expected" ]
+        assert_output $'status='"$expected"$'\nbuffer=git status'
+    done
+}

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -29,6 +29,13 @@ teardown() {
     run fzf-select-option -d mv
     assert_output "$(cat_static fzf-select-option-mv.txt)"
 }
+
+@test "Trims trailing whitespace from command input" {
+    run fzf-select-option -d <<< $'mv \t'
+
+    assert_success
+    assert_output "$(cat_static fzf-select-option-mv.txt)"
+}
     
 @test "Run with mv command and FZF_HELP_OPTS" {
     unset FZF_HELP_OPTS

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -92,3 +92,12 @@ teardown() {
     assert_success
     assert_output --partial '<--prompt=Select an option>'
 }
+
+@test "Run with a help message that has no options" {
+    export HELP_MESSAGE_CMD="printf 'No options\n'"
+
+    run fzf-select-option -d example
+
+    assert_success
+    assert_output --partial 'echo "No help page or options found for example"'
+}

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -94,10 +94,35 @@ teardown() {
 }
 
 @test "Run with a help message that has no options" {
+    local fzf_dir preview_file selection_file
+    fzf_dir="$BATS_TEST_TMPDIR/fzf-bin"
+    preview_file="$BATS_TEST_TMPDIR/preview-command"
+    selection_file="$BATS_TEST_TMPDIR/selection"
+    mkdir "$fzf_dir"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -euo pipefail' \
+        'read -r selection' \
+        'printf "%s\\n" "$selection" > "$FZF_HELP_TEST_SELECTION_FILE"' \
+        'while [[ $# -gt 0 ]]; do' \
+        '    if [[ $1 == --preview ]]; then' \
+        '        printf "%s\\n" "$2" > "$FZF_HELP_TEST_PREVIEW_FILE"' \
+        '        break' \
+        '    fi' \
+        '    shift' \
+        'done' \
+        'printf "%s\\n" "$selection"' > "$fzf_dir/fzf"
+    chmod +x "$fzf_dir/fzf"
     export HELP_MESSAGE_CMD="printf 'No options\n'"
 
-    run fzf-select-option -d example
+    run env \
+        PATH="$fzf_dir:$PATH" \
+        FZF_HELP_TEST_PREVIEW_FILE="$preview_file" \
+        FZF_HELP_TEST_SELECTION_FILE="$selection_file" \
+        fzf-select-option example
 
-    assert_success
-    assert_output --partial 'echo "No help page or options found for example"'
+    assert_failure
+    assert_output ""
+    assert_equal "$(<"$selection_file")" "No options available."
+    assert_equal "$(<"$preview_file")" 'echo "No help page or options found for example"'
 }


### PR DESCRIPTION
## Summary

- Keep the selector open when a help message has no recognized options.
- Preserve selector failures and cancellations in every shell widget.

## Issue

- Closes #39.

## Changes

- Treat `cli-options` status `1` as an empty option list.
- Show the empty-state preview instead of exiting.
- Update the Bash, Zsh, and Fish widgets to keep the command buffer on failure.
- Add widget tests for failed and cancelled selection.
- Install Fish and Zsh in CI for these tests.
- Add a changelog entry.

## Validation

- `git diff --check` passed.
- `bash -n src/fzf-select-option src/fzf-help.bash` passed.
- `zsh -n src/fzf-help.zsh` passed.
- `fish --no-execute src/fzf-help.fish` passed.
- `actionlint .github/workflows/test.yml` passed.
- `test/bats/bin/bats --tap test/fzf-select-option.bats test/fzf-help-widget.bats` passed: 9 tests.
- `./bats test` passed: 26 tests.

## Notes

- The selector treats status `1` from option extraction as an empty option list.
- PR #43 can conflict in the `2.3.3` changelog section while both PRs are unmerged.