### PR TITLE
Harden selector input handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bat
+          sudo apt-get install --yes bat zsh
           git submodule update --init --recursive
 
       - name: Run Bats Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ If a change is breaking, this is mentioned and a major version is released.
 
 # 2.3.3
 
+## Bug
+
+- The selector accepts one-character long options and rejects extra commands.
+- The shell integrations work when their path contains spaces.
+- `FZF_HELP_OPTS` preserves spaces in each fzf argument.
+
 ## Task
 
 - The AUR package now downloads the release tag.

--- a/README.md
+++ b/README.md
@@ -180,13 +180,16 @@ Note that only the following option formats are supported at the moment:
 The following environment variables can be set to configure the behaviour of
 `fzf-help`:
 
-- `FZF_HELP_OPTS`: options to pass to `fzf` when selecting the command to get
-  help for. Defaults to:
+- `FZF_HELP_OPTS`: arguments to pass to `fzf` when you select options. Put one
+  argument on each line. This format keeps spaces in an argument. The default
+  value is:
 
   ```bash
-  FZF_HELP_OPTS="--multi --layout=reverse --preview-window=right,75%,wrap --height 80% "
-  FZF_HELP_OPTS+="--bind ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)"
+  export FZF_HELP_OPTS=$'--multi\n--layout=reverse\n--preview-window=right,75%,wrap\n--height\n80%\n--bind\nctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)'
   ```
+
+  For example, use `--prompt=Select an option` on one line to set a prompt
+  that contains spaces.
 
 - `FZF_HELP_SYNTAX`: set this variable to configure the `bat --language=`
   option. It defaults to `txt`. If you use `bat` version 0.21 or higher, you can

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ The following environment variables can be set to configure the behaviour of
   For example, use `--prompt=Select an option` on one line to set a prompt
   that contains spaces.
 
+  A value with no newline uses the legacy space-separated format.
+
 - `FZF_HELP_SYNTAX`: set this variable to configure the `bat --language=`
   option. It defaults to `txt`. If you use `bat` version 0.21 or higher, you can
   set this variable to:

--- a/src/cli-options
+++ b/src/cli-options
@@ -33,7 +33,7 @@ PREFIX='(?:((?<=^)|(?<=[^\-]))(--|‐‐))'
 HEAD='a-zA-Z0-9\['
 MIDDLE='a-zA-Z0-9\[\]\-\=\.\,\%'
 TAIL='a-zA-Z0-9'
-LONG="$PREFIX([$HEAD]+[$MIDDLE]*[$TAIL]+)"
+LONG="$PREFIX([$HEAD](?:[$MIDDLE]*[$TAIL])?)"
 
 # Detects short options: -f or -F
 PREFIX='(?:((?<=^)|(?<=[^\-\_a-zA-Z0-9]))(-|‐))'

--- a/src/fzf-help.bash
+++ b/src/fzf-help.bash
@@ -1,4 +1,4 @@
-_fzf_help_directory=$(dirname $(realpath ${BASH_SOURCE:-$0}))
+_fzf_help_directory=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 
 ##############################################################################
 # fzf-help-widget
@@ -17,4 +17,3 @@ fzf-help-widget() {
     local ret=$?
     return $ret
 }
-

--- a/src/fzf-help.zsh
+++ b/src/fzf-help.zsh
@@ -1,4 +1,4 @@
-_fzf_help_directory=$(dirname $(realpath ${BASH_SOURCE:-$0}))
+_fzf_help_directory=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 
 ##############################################################################
 # fzf-help-widget

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -65,9 +65,13 @@ get_command() {
 
 get_fzf_help_opts() {
     if [[ -v FZF_HELP_OPTS ]]; then
-        while IFS= read -r fzf_help_opt; do
-            [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")
-        done <<<"$FZF_HELP_OPTS"
+        if [[ $FZF_HELP_OPTS == *$'\n'* ]]; then
+            while IFS= read -r fzf_help_opt; do
+                [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")
+            done <<<"$FZF_HELP_OPTS"
+        else
+            read -r -a fzf_help_opts <<<"$FZF_HELP_OPTS"
+        fi
     else
         fzf_help_opts=(
             --multi

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-_fzf_help_directory=$(dirname $(realpath "${BASH_SOURCE:-$0}"))
+_fzf_help_directory=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 source "$_fzf_help_directory"/fzf-help-log
 
 usage="Usage: $(basename "$0") [-h | --help] <cmd>
@@ -42,6 +42,10 @@ parse_args() {
                 exit 1
                 ;;
             *)
+                if [[ -n $cmd ]]; then
+                    echo "Only one command argument is allowed."
+                    exit 1
+                fi
                 cmd="$1"
                 shift
                 ;;
@@ -60,10 +64,21 @@ get_command() {
 }
 
 get_fzf_help_opts() {
-    local default
-    default="--multi --layout=reverse --preview-window=right,75%,wrap --height 80% "
-    default+="--bind ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)"
-    fzf_help_opts="${FZF_HELP_OPTS:-$default}"
+    if [[ -v FZF_HELP_OPTS ]]; then
+        while IFS= read -r fzf_help_opt; do
+            [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")
+        done <<<"$FZF_HELP_OPTS"
+    else
+        fzf_help_opts=(
+            --multi
+            --layout=reverse
+            --preview-window=right,75%,wrap
+            --height
+            80%
+            --bind
+            'ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)'
+        )
+    fi
 }
 
 get_preview_cmd() {
@@ -95,7 +110,7 @@ fzf_help_log "Time: $(date)"
 
 cmd=""
 fzf_cmd="fzf"
-fzf_help_opts=""
+fzf_help_opts=()
 parse_args "$@"
 [[ -z $cmd ]] && echo "$usage" && exit 1
 
@@ -105,4 +120,4 @@ dir=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
 opts="$("$dir/help-message" "$cmd" | "$dir/cli-options")"
 preview_cmd=$(get_preview_cmd)
 
-remove_line_number <<<"$opts" | $fzf_cmd --preview "$preview_cmd" $fzf_help_opts
+remove_line_number <<<"$opts" | "$fzf_cmd" --preview "$preview_cmd" "${fzf_help_opts[@]}"

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -64,7 +64,8 @@ get_command() {
 }
 
 get_fzf_help_opts() {
-    if [[ -v FZF_HELP_OPTS ]]; then
+    # Bash 3.2, which macOS provides, does not support [[ -v variable ]].
+    if [[ -n ${FZF_HELP_OPTS+x} ]]; then
         if [[ $FZF_HELP_OPTS == *$'\n'* ]]; then
             while IFS= read -r fzf_help_opt; do
                 [[ -n $fzf_help_opt ]] && fzf_help_opts+=("$fzf_help_opt")

--- a/test/cli-options.bats
+++ b/test/cli-options.bats
@@ -22,6 +22,12 @@ load helpers.bash
     assert_output "$(cat_static mv-options.txt)"
 }
 
+@test "Finds a one-character long option" {
+    run cli-options <<<'Use --x to enable the feature.'
+    assert_success
+    assert_output '1:--x'
+}
+
 @test "Set CLI_OPTIONS_CMD" {
     export CLI_OPTIONS_CMD="echo 'foo'"
     run cli-options <"$(static mv-help.txt)"

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -37,6 +37,15 @@ teardown() {
     assert_output "$(cat_static fzf-select-option-mv-fzf_help_opts.txt)"
 }
 
+@test "Supports legacy space-separated fzf arguments" {
+    export FZF_HELP_OPTS="--foo --bar"
+
+    run fzf-select-option -d mv
+
+    assert_success
+    assert_output "$(cat_static fzf-select-option-mv-fzf_help_opts.txt)"
+}
+
 @test "Sources the Bash integration from a path with spaces" {
     local source_dir source_file
     source_dir="$BATS_TEST_TMPDIR/source directory"

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -32,7 +32,54 @@ teardown() {
     
 @test "Run with mv command and FZF_HELP_OPTS" {
     unset FZF_HELP_OPTS
-    export FZF_HELP_OPTS="--foo --bar"
+    export FZF_HELP_OPTS=$'--foo\n--bar'
     run fzf-select-option -d mv
     assert_output "$(cat_static fzf-select-option-mv-fzf_help_opts.txt)"
+}
+
+@test "Sources the Bash integration from a path with spaces" {
+    local source_dir source_file
+    source_dir="$BATS_TEST_TMPDIR/source directory"
+    source_file="$source_dir/fzf-help.bash"
+    mkdir "$source_dir"
+    cp "$BATS_TEST_DIRNAME/../src/fzf-help.bash" "$source_file"
+
+    run bash -c 'source "$1"; printf "%s\\n" "$_fzf_help_directory"' bash "$source_file"
+
+    assert_success
+    assert_output "$source_dir"
+}
+
+@test "Sources the Zsh integration from a path with spaces" {
+    local source_dir source_file
+    source_dir="$BATS_TEST_TMPDIR/source directory"
+    source_file="$source_dir/fzf-help.zsh"
+    mkdir "$source_dir"
+    cp "$BATS_TEST_DIRNAME/../src/fzf-help.zsh" "$source_file"
+
+    run zsh -fc 'source "$1"; print -r -- "$_fzf_help_directory"' zsh "$source_file"
+
+    assert_success
+    assert_output "$source_dir"
+}
+
+@test "Reject two command arguments" {
+    run fzf-select-option mv cp
+
+    assert_failure
+    assert_output 'Only one command argument is allowed.'
+}
+
+@test "Passes an fzf argument with spaces as one argument" {
+    local fzf_dir
+    fzf_dir="$BATS_TEST_TMPDIR/fzf-bin"
+    mkdir "$fzf_dir"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "<%s>\\n" "$@"' > "$fzf_dir/fzf"
+    chmod +x "$fzf_dir/fzf"
+    export FZF_HELP_OPTS=$'--prompt=Select an option\n--height\n80%'
+
+    run env PATH="$fzf_dir:$PATH" FZF_HELP_OPTS="$FZF_HELP_OPTS" fzf-select-option mv
+
+    assert_success
+    assert_output --partial '<--prompt=Select an option>'
 }


### PR DESCRIPTION
## Summary

- Harden selector input parsing and fzf argument handling.
- Keep path names with spaces working in the Bash and Zsh integrations.

## Issue

- Closes #38.

## Changes

- Match one-character long options such as `--x`.
- Reject a second command argument with a clear error.
- Quote source-directory paths in the selector, Bash integration, and Zsh integration.
- Support newline-separated `FZF_HELP_OPTS` arguments without unsafe expansion.
- Preserve the legacy space-separated `FZF_HELP_OPTS` format.
- Document both supported `FZF_HELP_OPTS` formats.
- Add regression tests for all reported cases.

## Validation

- `git diff --check` passed.
- `bash -n src/cli-options src/fzf-select-option src/fzf-help.bash` passed.
- `zsh -n src/fzf-help.zsh` passed.
- `test/bats/bin/bats --tap test/cli-options.bats test/fzf-select-option.bats` passed: 16 tests, then 10 tests after the compatibility change.
- `./bats test` passed: 27 tests, then 28 tests after the compatibility change.

## Notes

- Use newline-separated entries when an fzf argument contains spaces.
- Values with no newline retain the existing space-separated format.