### PR TITLE
Prevent command-buffer execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ If a change is breaking, this is mentioned and a major version is released.
 - `FZF_HELP_OPTS` preserves spaces in each fzf argument.
 - The selector displays its empty preview if it finds no options.
 - The shell widgets preserve the command buffer when selection fails.
+- The help command does not run shell syntax from the command buffer.
 
 ## Task
 

--- a/README.md
+++ b/README.md
@@ -204,15 +204,16 @@ The following environment variables can be set to configure the behaviour of
   to get syntax highlighting for the `--help` documentation. Older versions of
   `bat` do not support this syntax highlighting, therefore the default is `txt`.
 
-- `HELP_MESSAGE_CMD`: controls which command is used to retrieve the command
-  line options. Here, the `$cmd` variable is the command to get the options for.
-  Defaults to `$cmd --help`. You can use `man -P cat $cmd` if you want to use the
-  man page instead of the `--help` documentation.
+- `HELP_MESSAGE_CMD`: controls the command that gets help text. By default,
+  `fzf-help` runs the selected command with `--help`. If you set this value,
+  `fzf-help` evaluates it as trusted Bash code. The `$cmd` variable contains
+  the validated command name. For example, set it to `man -P cat "$cmd"` to
+  use man pages.
 
 - `HELP_MESSAGE_RC`: set this environment variable to a file you want to be
   sourced before getting the help message. Typically, this file will contain
-  aliases and functions from which you may want to get the help message. When
-  this variable is set, alias expansion is also enabled.
+  functions for which you want to get help. The file is trusted Bash code. When
+  this variable is set, alias expansion is enabled for `HELP_MESSAGE_CMD`.
 
 - `CLI_OPTIONS_CMD`: set this environment variable to the command you want to
   use to retrieve the command line options. When defining the command, ensure
@@ -235,8 +236,8 @@ The following environment variables can be set to configure the behaviour of
 
   where `$RE` is the regular expression that is used to match the command line
   options. You can also add this to your custom command by adding `$RE` in your
-  command. For example, if you want to use `ag` instead of `grep`, you can set
-  `CLI_OPTIONS_CMD` to:
+  command. This value is trusted shell code. For example, if you want to use
+  `ag` instead of `grep`, you can set `CLI_OPTIONS_CMD` to:
 
   ```bash
   export CLI_OPTIONS_CMD='ag -o --numbers -- $RE'

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ The following environment variables can be set to configure the behaviour of
 - `HELP_MESSAGE_CMD`: controls the command that gets help text. By default,
   `fzf-help` runs the selected command with `--help`. If you set this value,
   `fzf-help` evaluates it as trusted Bash code. The `$cmd` variable contains
-  the validated command name. For example, set it to `man -P cat "$cmd"` to
-  use man pages.
+  validated command text. It can include an executable path or subcommands.
+  For example, set it to `man -P cat "$cmd"` to use man pages.
 
 - `HELP_MESSAGE_RC`: set this environment variable to a file you want to be
   sourced before getting the help message. Typically, this file will contain

--- a/src/help-message
+++ b/src/help-message
@@ -15,7 +15,8 @@ The default command is:
     <cmd> --help
 
 When you set HELP_MESSAGE_CMD, fzf-help evaluates it as trusted Bash code. It
-sets the \$cmd variable to the validated command name.
+sets the \$cmd variable to validated command text. The text can include an
+executable path or subcommands.
 
 where:
     options:
@@ -32,26 +33,29 @@ parse_args() {
                 exit 0
                 ;;
             *)
-                if [[ -z $cmd ]]; then
-                    cmd="$1"
-                else
-                    echo "Unknown argument: $1"
-                    echo "$usage"
-                    exit 1
-                fi
+                cmd_parts+=("$1")
                 ;;
         esac
         shift
     done
 }
 
+cmd_parts=()
+cmd_args=()
 cmd=""
 parse_args "$@"
 
-if [[ -n $cmd && ! $cmd =~ ^[a-zA-Z0-9_.+-]+$ ]]; then
-    echo "The command name contains unsupported characters." >&2
-    exit 1
-fi
+for cmd_part in "${cmd_parts[@]}"; do
+    if [[ ! $cmd_part =~ ^[a-zA-Z0-9_./:+@%=-]+([[:space:]][a-zA-Z0-9_./:+@%=-]+)*$ ]]; then
+        echo "The command contains unsupported characters." >&2
+        exit 1
+    fi
+
+    read -r -a parsed_args <<<"$cmd_part"
+    cmd_args+=("${parsed_args[@]}")
+done
+
+cmd="${cmd_args[*]}"
 
 help_message=$("$_fzf_help_directory"/make-temp "fzf-help-message")
 help_message_cmd="${HELP_MESSAGE_CMD:-}"
@@ -70,7 +74,7 @@ if [[ -n $cmd ]]; then
     if [[ -n $help_message_cmd ]]; then
         eval "$help_message_cmd" >"$help_message" || true
     else
-        "$cmd" --help >"$help_message" || true
+        "${cmd_args[@]}" --help >"$help_message" || true
     fi
 fi
 

--- a/src/help-message
+++ b/src/help-message
@@ -40,22 +40,64 @@ parse_args() {
     done
 }
 
+is_safe_command_part() {
+    [[ $1 =~ ^[a-zA-Z0-9_./:+@%=-]+([[:space:]][a-zA-Z0-9_./:+@%=-]+)*$ ]]
+}
+
+add_command_part() {
+    local command_part=$1
+    local parsed_args
+
+    if ! is_safe_command_part "$command_part"; then
+        echo "The command contains unsupported characters." >&2
+        return 1
+    fi
+
+    read -r -a parsed_args <<<"$command_part"
+    cmd_args+=("${parsed_args[@]}")
+}
+
+set_command_args() {
+    local command_part
+
+    for command_part in "${cmd_parts[@]}"; do
+        add_command_part "$command_part"
+    done
+
+    cmd="${cmd_args[*]}"
+}
+
+source_help_message_rc() {
+    if [[ -f $help_message_rc ]]; then
+        shopt -s expand_aliases
+        . "$help_message_rc"
+    fi
+}
+
+write_custom_help_message() {
+    eval "$help_message_cmd" >"$help_message" || true
+}
+
+write_default_help_message() {
+    "${cmd_args[@]}" --help >"$help_message" || true
+}
+
+write_help_message() {
+    [[ -z $cmd ]] && return
+
+    if [[ -n $help_message_cmd ]]; then
+        write_custom_help_message
+    else
+        write_default_help_message
+    fi
+}
+
 cmd_parts=()
 cmd_args=()
 cmd=""
 parse_args "$@"
 
-for cmd_part in "${cmd_parts[@]}"; do
-    if [[ ! $cmd_part =~ ^[a-zA-Z0-9_./:+@%=-]+([[:space:]][a-zA-Z0-9_./:+@%=-]+)*$ ]]; then
-        echo "The command contains unsupported characters." >&2
-        exit 1
-    fi
-
-    read -r -a parsed_args <<<"$cmd_part"
-    cmd_args+=("${parsed_args[@]}")
-done
-
-cmd="${cmd_args[*]}"
+set_command_args
 
 help_message=$("$_fzf_help_directory"/make-temp "fzf-help-message")
 help_message_cmd="${HELP_MESSAGE_CMD:-}"
@@ -64,18 +106,7 @@ fzf_help_log "Custom help command is: $help_message_cmd"
 fzf_help_log "Help message file is: $help_message"
 fzf_help_log "Aliases: $help_message_rc"
 
-if [ -f "$help_message_rc" ]; then
-    shopt -s expand_aliases
-    . "$help_message_rc"
-fi
-    
-
-if [[ -n $cmd ]]; then
-    if [[ -n $help_message_cmd ]]; then
-        eval "$help_message_cmd" >"$help_message" || true
-    else
-        "${cmd_args[@]}" --help >"$help_message" || true
-    fi
-fi
+source_help_message_rc
+write_help_message
 
 cat "$help_message" > /dev/stdout

--- a/src/help-message
+++ b/src/help-message
@@ -6,16 +6,16 @@ source "$_fzf_help_directory"/fzf-help-log
 
 usage="Usage: $(basename "$0") [-h | --help] <cmd>
 
-Evaluates the HELP_MESSAGE_CMD environment variable and writes the result to
-stdout and a temp file. If no <cmd> argument is given, then the content of
-the temp file is written to stdout, i.e, the help message of the command that
-was last evaluated.
+Writes the help message for <cmd> to stdout and a temp file. If no <cmd>
+argument is given, it writes the content of the temp file to stdout. The file
+contains the help message from the last command.
 
-The default values of HELP_MESSAGE_CMD is:
+The default command is:
 
-    export HELP_MESSAGE_CMD='\$cmd --help'
+    <cmd> --help
 
-here, you can \$cmd as a placeholder for the <cmd> argument.
+When you set HELP_MESSAGE_CMD, fzf-help evaluates it as trusted Bash code. It
+sets the \$cmd variable to the validated command name.
 
 where:
     options:
@@ -48,10 +48,15 @@ parse_args() {
 cmd=""
 parse_args "$@"
 
+if [[ -n $cmd && ! $cmd =~ ^[a-zA-Z0-9_.+-]+$ ]]; then
+    echo "The command name contains unsupported characters." >&2
+    exit 1
+fi
+
 help_message=$("$_fzf_help_directory"/make-temp "fzf-help-message")
-help_message_cmd="${HELP_MESSAGE_CMD:-$cmd --help}"
+help_message_cmd="${HELP_MESSAGE_CMD:-}"
 help_message_rc="${HELP_MESSAGE_RC:-""}"
-fzf_help_log "Help command is: $help_message_cmd"
+fzf_help_log "Custom help command is: $help_message_cmd"
 fzf_help_log "Help message file is: $help_message"
 fzf_help_log "Aliases: $help_message_rc"
 
@@ -61,6 +66,12 @@ if [ -f "$help_message_rc" ]; then
 fi
     
 
-[[ $cmd ]] && { eval "$help_message_cmd" >"$help_message" || true; }
+if [[ -n $cmd ]]; then
+    if [[ -n $help_message_cmd ]]; then
+        eval "$help_message_cmd" >"$help_message" || true
+    else
+        "$cmd" --help >"$help_message" || true
+    fi
+fi
 
 cat "$help_message" > /dev/stdout

--- a/test/help-message.bats
+++ b/test/help-message.bats
@@ -47,7 +47,31 @@ setup() {
 }
 
 @test "Set HELP_MESSAGE_CMD" {
-    export HELP_MESSAGE_CMD="echo \$cmd"
+    export HELP_MESSAGE_CMD='printf "custom:%s\\n" "$cmd"'
     run help-message ls
-    assert_output "ls"
+    assert_output "custom:ls"
+}
+
+@test "Runs the default command with --help" {
+    local command_dir
+    command_dir="$BATS_TEST_TMPDIR/commands"
+    mkdir "$command_dir"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "argument=%s\\n" "$1"' > "$command_dir/example-command"
+    chmod +x "$command_dir/example-command"
+
+    run env PATH="$command_dir:$PATH" help-message example-command
+
+    assert_success
+    assert_output "argument=--help"
+}
+
+@test "Does not run shell syntax from the command argument" {
+    local marker
+    marker="$BATS_TEST_TMPDIR/command-ran"
+
+    run help-message "example; touch $marker"
+
+    assert_failure
+    assert_output "The command name contains unsupported characters."
+    [ ! -e "$marker" ]
 }

--- a/test/help-message.bats
+++ b/test/help-message.bats
@@ -65,6 +65,30 @@ setup() {
     assert_output "argument=--help"
 }
 
+@test "Runs executable paths and subcommands" {
+    local command command_dir
+    command_dir="$BATS_TEST_TMPDIR/commands"
+    command="$command_dir/example-command"
+    mkdir "$command_dir"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "arguments=%s\\n" "$*"' > "$command"
+    chmod +x "$command"
+
+    run help-message "$command"
+
+    assert_success
+    assert_output "arguments=--help"
+
+    run env PATH="$command_dir:$PATH" help-message example-command status
+
+    assert_success
+    assert_output "arguments=status --help"
+
+    run env PATH="$command_dir:$PATH" help-message "example-command status"
+
+    assert_success
+    assert_output "arguments=status --help"
+}
+
 @test "Does not run shell syntax from the command argument" {
     local marker
     marker="$BATS_TEST_TMPDIR/command-ran"
@@ -72,6 +96,6 @@ setup() {
     run help-message "example; touch $marker"
 
     assert_failure
-    assert_output "The command name contains unsupported characters."
+    assert_output "The command contains unsupported characters."
     [ ! -e "$marker" ]
 }


### PR DESCRIPTION
## Summary

- Prevent command-buffer text from being evaluated as shell syntax.
- Keep documented custom help commands available as trusted Bash code.

## Issue

- Closes #40.

## Changes

- Run the default help command as `<command> --help` without `eval`.
- Reject command names that contain unsupported characters.
- Run custom `HELP_MESSAGE_CMD` values separately from the command buffer.
- Document trusted shell-code configuration values.
- Add default-command and shell-metacharacter regression tests.

## Validation

- `git diff --check` passed.
- `bash -n src/help-message` passed.
- `test/bats/bin/bats --tap test/help-message.bats` passed: 8 tests.
- `./bats test` passed: 24 tests.

## Notes

- `HELP_MESSAGE_CMD`, `HELP_MESSAGE_RC`, and `CLI_OPTIONS_CMD` are trusted user configuration. The command-buffer value is validated and is not interpolated into the default command.