### PR TITLE
Use an isolated help-message cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ If a change is breaking, this is mentioned and a major version is released.
 - The shell widgets preserve the command buffer when selection fails.
 - The help command does not run shell syntax from the command buffer.
 - The logger no longer writes device paths to the program output.
+- Each selector session now uses and removes its own help-message cache file.
 
 ## Deprecated
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ The following environment variables can be set to configure the behaviour of
 - `FZF_HELP_LOG_LINES`: the number of lines to keep in the log file. Defaults to
   `10000`.
 
+### Help-message cache
+
+Each `fzf-select-option` session creates one temporary help-message file. The
+preview process reads this file. The selector removes the file when fzf exits.
+
+A standalone `help-message <cmd>` call uses a temporary file only while the
+command runs. It does not preserve a cache. A standalone `help-message` call
+with no command prints no previous help message.
+
 ## Tests
 
 Install `bat` before you run the tests.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [With package manager](#with-package-manager)
 - [Usage](#usage)
 - [Configuration](#configuration)
+- [Development notes](#development-notes)
 - [Tests](#tests)
 - [Release process](#release-process)
 - [Troubleshooting](#troubleshooting)
@@ -251,6 +252,8 @@ The following environment variables can be set to configure the behaviour of
 
 - `FZF_HELP_LOG_LINES`: the number of lines to keep in the log file. Defaults to
   `10000`.
+
+## Development notes
 
 ### Help-message cache
 

--- a/src/fzf-select-option
+++ b/src/fzf-select-option
@@ -108,13 +108,19 @@ set_fzf_help_opts() {
 get_options() {
     local options status
 
-    if options=$("$dir/help-message" "$cmd" | "$dir/cli-options"); then
+    if options=$(FZF_HELP_MESSAGE_PATH="$help_message" "$dir/help-message" "$cmd" | "$dir/cli-options"); then
         printf '%s\n' "$options"
     else
         status=$?
         [[ $status -eq 1 ]] && return 0
         return "$status"
     fi
+}
+
+shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
 }
 
 get_preview_cmd() {
@@ -124,7 +130,10 @@ get_preview_cmd() {
         printf 'echo "No help page or options found for %s"\n' "$cmd"
     else
         # Uses the cached help message, see help-message.
-        printf '%s\n' "$dir/help-message | $dir/fzf-select-option-preview \"$options\" {n}"
+        printf 'cat %s | %s %s {n}\n' \
+            "$(shell_quote "$help_message")" \
+            "$(shell_quote "$dir/fzf-select-option-preview")" \
+            "$(shell_quote "$options")"
     fi
 }
 
@@ -166,6 +175,7 @@ fzf_debug() {
     msg="stdin:\n$(cat -)\n"
     shift
     preview_cmd_no_path=${1//$dir\//}
+    preview_cmd_no_path=${preview_cmd_no_path//$help_message/<cache>}
     msg+="\npreview cmd:\n$preview_cmd_no_path\n"
     shift
     msg+="\nfzf_help_opts:\n${*}"
@@ -184,6 +194,8 @@ parse_args "$@"
 set_fzf_help_opts
 
 dir=$(dirname "$(realpath "${BASH_SOURCE:-$0}")")
+help_message=$("$dir/make-temp" "fzf-help-message")
+trap 'rm -f "$help_message"' EXIT
 options=$(get_options)
 preview_cmd=$(get_preview_cmd "$options")
 show_options "$options" "$preview_cmd"

--- a/src/help-message
+++ b/src/help-message
@@ -99,7 +99,12 @@ parse_args "$@"
 
 set_command_args
 
-help_message=$("$_fzf_help_directory"/make-temp "fzf-help-message")
+if [[ -n ${FZF_HELP_MESSAGE_PATH:-} ]]; then
+    help_message="$FZF_HELP_MESSAGE_PATH"
+else
+    help_message=$("$_fzf_help_directory"/make-temp "fzf-help-message")
+    trap 'rm -f "$help_message"' EXIT
+fi
 help_message_cmd="${HELP_MESSAGE_CMD:-}"
 help_message_rc="${HELP_MESSAGE_RC:-""}"
 fzf_help_log "Custom help command is: $help_message_cmd"

--- a/src/make-temp
+++ b/src/make-temp
@@ -23,7 +23,5 @@ if [[ $1 == "-h" || $1 == "--help" ]]; then
 fi
 
 name=$1
-tmpdir=$(dirname "$(mktemp -u)")
-file="$tmpdir/$name"
-touch "$file"
-echo "$file"
+tmpdir=${TMPDIR:-/tmp}
+mktemp "$tmpdir/$name.XXXXXXXXXX"

--- a/test/fzf-select-option.bats
+++ b/test/fzf-select-option.bats
@@ -133,3 +133,24 @@ teardown() {
     assert_equal "$(<"$selection_file")" "No options available."
     assert_equal "$(<"$preview_file")" 'echo "No help page or options found for example"'
 }
+
+@test "Uses a unique cache file for each selector session" {
+    local fzf_dir first_preview first_cache second_preview second_cache
+    fzf_dir="$BATS_TEST_TMPDIR/fzf-bin"
+    mkdir "$fzf_dir"
+    printf '%s\n' '#!/usr/bin/env bash' 'while [[ $# -gt 0 ]]; do' '    if [[ $1 == --preview ]]; then' '        cache=$(printf "%s\\n" "$2" | sed -n "s/^cat '\''\\(.*\\)'\'' |.*$/\\1/p")' '        printf "cache=%s\\n" "$cache"' '        cat "$cache"' '        exit 0' '    fi' '    shift' 'done' > "$fzf_dir/fzf"
+    chmod +x "$fzf_dir/fzf"
+
+    run env PATH="$fzf_dir:$PATH" fzf-select-option mv
+    assert_success
+    first_preview="${output%%$'\n'*}"
+    first_cache=${first_preview#cache=}
+    [ ! -e "$first_cache" ]
+
+    run env PATH="$fzf_dir:$PATH" fzf-select-option mv
+    assert_success
+    second_preview="${output%%$'\n'*}"
+    second_cache=${second_preview#cache=}
+    [ ! -e "$second_cache" ]
+    [ "$first_cache" != "$second_cache" ]
+}

--- a/test/help-message.bats
+++ b/test/help-message.bats
@@ -4,24 +4,6 @@ load test_helper/bats-assert/load
 load test_helper/bats-support/load
 load helpers.bash
 
-get_temp() {
-    local tmpdir
-    tmpdir=$(dirname "$(mktemp tmp.XXXXXXXXXX -ut)")
-    echo "$tmpdir/fzf-help-message"
-}
-
-rm_temp() {
-    local file
-    file=$(get_temp)
-    if [[ -f $file ]]; then
-        rm "$file"
-    fi
-}
-
-setup() {
-    rm_temp
-}
-
 @test "Run without command" {
     help-message
 }
@@ -40,10 +22,10 @@ setup() {
     assert_output "$(ls --help)"
 }
 
-@test "Cached help message" {
+@test "Standalone calls do not retain a help-message cache" {
     help-message ls
     run help-message
-    assert_output "$(ls --help)"
+    assert_output ""
 }
 
 @test "Set HELP_MESSAGE_CMD" {

--- a/test/make-temp.bats
+++ b/test/make-temp.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+# vim: ft=bash
+load test_helper/bats-assert/load
+load test_helper/bats-support/load
+
+@test "Creates unique temporary files" {
+    local first second
+
+    run make-temp fzf-help-message
+    assert_success
+    first="$output"
+    [ -f "$first" ]
+
+    run make-temp fzf-help-message
+    assert_success
+    second="$output"
+    [ -f "$second" ]
+    [ "$first" != "$second" ]
+
+    rm -f "$first" "$second"
+}

--- a/test/static/fzf-select-option-mv-fzf_help_opts.txt
+++ b/test/static/fzf-select-option-mv-fzf_help_opts.txt
@@ -40,7 +40,7 @@ stdin:
 --backup
 
 preview cmd:
-help-message | fzf-select-option-preview "1:-T
+cat '<cache>' | 'fzf-select-option-preview' '1:-T
 3:-t
 7:--backup[=CONTROL
 8:-b
@@ -78,7 +78,7 @@ help-message | fzf-select-option-preview "1:-T
 34:--update
 37:--suffix
 38:--backup
-41:--backup" {n}
+41:--backup' {n}
 
 fzf_help_opts:
 --foo --bar

--- a/test/static/fzf-select-option-mv.txt
+++ b/test/static/fzf-select-option-mv.txt
@@ -40,7 +40,7 @@ stdin:
 --backup
 
 preview cmd:
-help-message | fzf-select-option-preview "1:-T
+cat '<cache>' | 'fzf-select-option-preview' '1:-T
 3:-t
 7:--backup[=CONTROL
 8:-b
@@ -78,7 +78,7 @@ help-message | fzf-select-option-preview "1:-T
 34:--update
 37:--suffix
 38:--backup
-41:--backup" {n}
+41:--backup' {n}
 
 fzf_help_opts:
 --multi --layout=reverse --preview-window=right,75%,wrap --height 80% --bind ctrl-a:change-preview-window(down,75%,nowrap|right,75%,nowrap)


### PR DESCRIPTION
## Summary

- Give each selector session a private, atomically created help-message cache.
- Remove the cache when the selector exits.

## Issue

- Closes #42.

## Changes

- Replace `mktemp -u` and a predictable file name with a unique `mktemp` file.
- Create one cache file for each `fzf-select-option` session.
- Pass the exact cache path to the preview command.
- Remove the selector cache through an exit trap.
- Remove standalone help-message caches when each call exits.
- Document the cache behavior.
- Add cache uniqueness, preview-read, and cleanup regression tests.

## Validation

- `git diff --check` passed.
- `bash -n src/make-temp src/help-message src/fzf-select-option` passed.
- `test/bats/bin/bats --tap test/make-temp.bats test/help-message.bats test/fzf-select-option.bats` passed: 13 tests.
- `./bats test` passed: 24 tests.

## Notes

- Preview commands use POSIX-compatible shell quoting for the cache path and option list.
- Standalone `help-message <cmd>` calls retain no cache after the command exits.